### PR TITLE
should generate one more hash for empty cell

### DIFF
--- a/src/klotski.js
+++ b/src/klotski.js
@@ -160,7 +160,7 @@
 
     function makeCellState(numTypes, cr) {
       var i;
-      for (i = 0; i < numTypes; i++) {
+      for (i = 0; i < numTypes + 1; i++) {
         cr.value[i] = random32();
       }
     }


### PR DESCRIPTION
we should generate a zobrist hash table of `[row][col][numTypes+1]`, the additional one is for the empty cell, ie `[row][col][0]` in this case.